### PR TITLE
Ruby 2.3 change to Jessie

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ruby:2.3-jessie
 MAINTAINER Campus Code <dev@campuscode.com.br>
 
 ENV NODE_VERSION 7


### PR DESCRIPTION
Because of openssh changes of how ssh keys are generating i'm changing this image back to Jessie version of linux