### PR TITLE
Include Dockerfile for Ruby 2.6

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.6
+MAINTAINER Campus Code <dev@campuscode.com.br>
+
+ENV NODE_VERSION 8
+RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
+
+RUN apt-get update -qq
+RUN apt-get install -y --no-install-recommends nodejs \
+      locales \
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+RUN locale-gen
+ENV LC_ALL en_US.utf8
+
+RUN gem install bundler-audit


### PR DESCRIPTION
## Motivação

Criação de uma imagem para ser utilizada no Gitlab CI atualizada para ruby 2.6

## Solução Proposta

Criação de um Dockerfile baseado na nova imagem do ruby 2.6

## Links

https://hub.docker.com/_/ruby/