### PR TITLE
Fix Dockerfile for Ruby 2.6

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -
 
 RUN apt-get update -qq
 RUN apt-get install -y --no-install-recommends nodejs \
-      locales \
+      locales
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
 RUN locale-gen


### PR DESCRIPTION
## Motivação

Ao remover um apt da imagem ficou um `\` o que causa erro ao buildar o Docker